### PR TITLE
修复 send_search_setu 正则表达式

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -257,7 +257,7 @@ async def send_setu(bot, ev):
 	await bot.send(ev, msg)
 
 
-@sv.on_rex(r'^[色涩瑟][图圖]|[来來发發给給]((?P<num>\d+)|(?:.*))[张張个個幅点點份丶](?P<keyword>.*?)[色涩瑟][图圖]$')
+@sv.on_rex(r'^[色涩瑟][图圖]$|^[来來发發给給]((?P<num>\d+)|(?:.*))[张張个個幅点點份丶](?P<keyword>.*?)[色涩瑟][图圖]$')
 async def send_search_setu(bot, ev):
 	uid = ev['user_id']
 	gid = ev['group_id']


### PR DESCRIPTION
例如
`涩图bot哪来的` 
将会触发原来的触发器