### PR TITLE
修复 当使用render_forward_msg时 tlmt与预期不符的BUG

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -155,7 +155,7 @@ async def send_msg(msg_list, ev):
 			hoshino.logger.error('[ERROR]图片发送失败')
 			await hoshino.get_bot().send(ev, f'涩图太涩,发不出去力...')
 		await asyncio.sleep(1)
-		return list(range(1, len(msg_list)))
+		return list(range(len(msg_list)))
 
 
 @sv.on_prefix('setu')


### PR DESCRIPTION
当使用render_forward_msg时 send_msg最后会走到range(1 , len(msg_list)) 当群友只要1张涩图时 执行为range(1 , 1)从1开始到1结束 那么将会不进行循环 输出的list为空 所以tlmt将不会生效，当群友要复数张涩图时 将永远少减少一次上限，通过修改为range(len(msg_list))尝试修复