### PR TITLE
解决直连出错的问题

### DIFF
--- a/lolicon.py
+++ b/lolicon.py
@@ -73,7 +73,7 @@ async def query_setu(r18=0, keyword=None):
 	if thumb:
 		params['size'] = 'regular'
 	if get_config('lolicon', 'pixiv_direct'):
-		params['proxy'] = 'disable'
+		params['proxy'] = ''
 	
 	try:
 		async with aiohttp.ClientSession() as session:
@@ -122,7 +122,7 @@ async def download_image(url: str):
 
 
 async def download_pixiv_image(url: str, id):
-	hoshino.logger.info('[INFO]lolicon downloading pixiv image', url)
+	hoshino.logger.info(f'[INFO]lolicon downloading pixiv image:{url}')
 	headers = {
 		'referer': f'https://www.pixiv.net/member_illust.php?mode=medium&illust_id={id}'
 	}


### PR DESCRIPTION
fixed #51 ；API中用于获取原始链接的proxy参数在v2版本已经更改为 任何假值("",0,false,null) ，v1版本的 disable 会导致返回错误的链接；logger带参数的话也会报错，改成了上面的写法。